### PR TITLE
Remove redundant build flags

### DIFF
--- a/com.github.birros.WebArchives.yml
+++ b/com.github.birros.WebArchives.yml
@@ -22,9 +22,6 @@ finish-args:
   - --filesystem=~/.config/dconf:ro
   - --talk-name=ca.desrt.dconf
   - --env=DCONF_USER_CONFIG_DIR=.config/dconf
-build-options:
-  cflags: -O2 -g
-  cxxflags: -O2 -g
 modules:
   - name: xapian-core
     config-opts:


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.